### PR TITLE
Font extension 추가, 메인화면 타이틀 텍스트 잘리는 현상 수정

### DIFF
--- a/Transform/Font/FontManager.swift
+++ b/Transform/Font/FontManager.swift
@@ -7,9 +7,36 @@
 
 import SwiftUI
 
-class FontManager {
-    struct Poppins {
-        static let semibold = "Poppins-SemiBold"
-        static let medium = "Poppins-Medium"
+//MARK: Font Extension
+/*
+ 커스텀 폰트 사용을 도와주는 extension
+ 
+ 다음과 같이 사용한다.
+ Text("Hello, World!")
+     .font(.poppins(.semibold, size: 50))
+ 
+ Text("Hello, World!")
+     .font(.poppins(.medium))
+ */
+extension Font {
+    enum Poppins {
+        case semibold
+        case medium
+        case custom(String)
+        
+        var value: String {
+            switch self {
+            case .semibold:
+                return "Poppins-SemiBold"
+            case .medium:
+                return "Poppins-Medium"
+            case .custom(let name):
+                return name
+            }
+        }
+    }
+
+    static func poppins(_ type: Poppins, size: CGFloat = 17) -> Font {
+        return .custom(type.value, size: size)
     }
 }

--- a/Transform/Views/Main/MainView.swift
+++ b/Transform/Views/Main/MainView.swift
@@ -42,7 +42,8 @@ struct MainView: View {
                 .toolbar {
                     ToolbarItem(placement: .principal) {
                         Text("Bamboothon")
-                            .font(.custom(FontManager.Poppins.semibold, size: 20))
+                            .font(.poppins(.semibold, size: 20))
+                            .multilineTextAlignment(.leading)
                             .foregroundColor(Color("accentYellow"))
                             .accessibilityAddTraits(.isHeader)
                     }

--- a/Transform/Views/Main/TabBarButton.swift
+++ b/Transform/Views/Main/TabBarButton.swift
@@ -18,7 +18,7 @@ struct TabBarButton: View {
         }) {
             VStack(spacing: 5){
                 Text(item)
-                    .font(.custom(FontManager.Poppins.semibold, size: 15))
+                    .font(.poppins(.semibold, size: 15))
                     .foregroundColor(current == item ? Color("accentYellow") : Color("accentYellow").opacity(0.5))
                     .frame(height: 35)
 


### PR DESCRIPTION
# 배경
- 여러개의 폰트가 추가되어 관리의 필요성이 생겼습니다.
- MainView 에서 타이틀 뒷부분이 잘려 보이지 않는 현상을 발견했습니다.

# 작업내용
- #11 
  - Font에 커스텀 폰트를 쓸 수 있는 메소드를 추가하였습니다.

- #3 
  - 타이틀에 텍스트가 잘리는 현상을 해결했습니다.

# 스크린샷
<img src = "https://user-images.githubusercontent.com/57349859/199048502-6698c8ca-71fe-46b0-a09a-d598e804ffb6.png" width="30%" height="30%">
